### PR TITLE
Observer Lists using custom mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /local.properties
 /.idea/workspace.xml
 /.idea/libraries
+/.idea/vcs.xml
+/.idea/misc.xml
+/.idea/modules.xml
 .DS_Store
 /build
 /captures

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,12 +8,12 @@ android {
         exclude 'META-INF/NOTICE'
     }
 
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 2
         versionName "0.5"
     }
@@ -27,12 +27,12 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    provided 'com.google.firebase:firebase-auth:9.6.1'
-    provided 'com.google.firebase:firebase-database:9.6.1'
-    provided 'com.google.firebase:firebase-storage:9.6.1'
-    provided 'com.android.support:recyclerview-v7:24.0.0'
-    compile 'io.reactivex.rxjava2:rxjava:2.0.0-RC5'
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.0-RC1'
+    provided 'com.google.firebase:firebase-auth:10.0.1'
+    provided 'com.google.firebase:firebase-database:10.0.1'
+    provided 'com.google.firebase:firebase-storage:10.0.1'
+    provided 'com.android.support:recyclerview-v7:25.1.1'
+    compile 'io.reactivex.rxjava2:rxjava:2.0.4'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:2.2.16"
 }

--- a/app/src/main/java/durdinapps/rxfirebase2/DataSnapshotMapper.java
+++ b/app/src/main/java/durdinapps/rxfirebase2/DataSnapshotMapper.java
@@ -24,6 +24,10 @@ public abstract class DataSnapshotMapper<T, U> implements Function<T, U> {
       return new TypedListDataSnapshotMapper<>(clazz);
    }
 
+   public static <U> DataSnapshotMapper<DataSnapshot, List<U>> listOf(Class<U> clazz, Function<DataSnapshot, U> mapper) {
+      return new TypedListDataSnapshotMapper<>(clazz, mapper);
+   }
+
    public static <U> DataSnapshotMapper<DataSnapshot, LinkedHashMap<String, U>> mapOf(Class<U> clazz) {
       return new TypedMapDataSnapshotMapper<>(clazz);
    }
@@ -66,16 +70,24 @@ public abstract class DataSnapshotMapper<T, U> implements Function<T, U> {
    private static class TypedListDataSnapshotMapper<U> extends DataSnapshotMapper<DataSnapshot, List<U>> {
 
       private final Class<U> clazz;
+      private final Function<DataSnapshot, U> mapper;
 
-      public TypedListDataSnapshotMapper(final Class<U> clazz) {
+      TypedListDataSnapshotMapper(final Class<U> clazz) {
+         this(clazz, null);
+      }
+
+      TypedListDataSnapshotMapper(final Class<U> clazz, Function<DataSnapshot, U> mapper) {
          this.clazz = clazz;
+         this.mapper = mapper;
       }
 
       @Override
-      public List<U> apply(final DataSnapshot dataSnapshot) {
+      public List<U> apply(final DataSnapshot dataSnapshot) throws Exception {
          List<U> items = new ArrayList<>();
          for (DataSnapshot childSnapshot : dataSnapshot.getChildren()) {
-            items.add(getDataSnapshotTypedValue(childSnapshot, clazz));
+            items.add(mapper != null
+                    ? mapper.apply(childSnapshot)
+                    : getDataSnapshotTypedValue(childSnapshot, clazz));
          }
          return items;
       }
@@ -85,7 +97,7 @@ public abstract class DataSnapshotMapper<T, U> implements Function<T, U> {
 
       private final Class<U> clazz;
 
-      public TypedMapDataSnapshotMapper(final Class<U> clazz) {
+      TypedMapDataSnapshotMapper(final Class<U> clazz) {
          this.clazz = clazz;
       }
 


### PR DESCRIPTION
This PR facilitates observing a List that needs a custom mapper by adding this static method to DataSnapshotMapper

```
DataSnapshotMapper.listOf(Class<U> clazz, Function<DataSnapshot, U> mapper)
```

I've added two tests to *RxFirebaseDatabaseTest*

It also updates some outdated dependencies and fixes a test that failed to compile after Firebase version bump.

If you think it's useful, I can do the same for Map values.

With version 0.5, this behavior can be achieved but it's really verbose (1 custom class + 1 Function implementation)